### PR TITLE
Central Difference

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -188,6 +188,27 @@ impl fmt::Display for SymmetryConstraint {
     }
 }
 
+#[derive(Serialize, Deserialize, Debug)]
+/// Sets the precision of the central difference formalism.
+pub enum CentralDifference {
+    /// 3 point, good to 𝓞(`grid.dn`²).
+    ThreePoint,
+    /// 5 point, good to 𝓞(`grid.dn`⁴).
+    FivePoint,
+    /// 7 point, good to 𝓞(`grid.dn`⁶).
+    SevenPoint,
+}
+
+impl fmt::Display for CentralDifference {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            CentralDifference::ThreePoint => write!(f, "Three point: O(Δ{{x,y,z}}²)"),
+            CentralDifference::FivePoint => write!(f, "Three point: O(Δ{{x,y,z}}⁴)"),
+            CentralDifference::SevenPoint => write!(f, "Three point: O(Δ{{x,y,z}}⁶)"),
+        }
+    }
+}
+
 //TODO: This isn't implimented at all yet. May not be needed.
 #[derive(Serialize, Deserialize, Debug)]
 /// Sets the type of run Wafer will execute.
@@ -290,6 +311,9 @@ pub struct Config {
     pub grid: Grid,
     /// A convergence value, how accurate the total energy needs to be.
     pub tolerance: f64,
+    /// Precision of the central difference formalism. The higher the value here the
+    /// lower the resultant error will be, provided the step size has been optimally chosen.
+    pub central_difference: CentralDifference,
     /// The maximum amount of steps the solver should attempt before giving up.
     pub max_steps: u64,
     /// A starting number pertaining to an excited state energy level. To start
@@ -383,6 +407,11 @@ impl Config {
                      format!("Save wavefns: {}", self.output.save_wavefns),
                      format!("Save potential: {}", self.output.save_potential),
                      width = colwidth);
+            println!("{:5}{:<width$}{:<width$}",
+                     "",
+                     format!("CD precision: {}", self.central_difference),
+                     format!("Output file format: {}", if self.output.binary_files { "Binary"} else { "Plaintext" }),
+                     width = dcolwidth);
             println!("{:5}{:<twidth$}{:<width$}",
                      "",
                      format!("Potential: {}", self.potential),
@@ -446,6 +475,11 @@ impl Config {
                      "",
                      format!("Save wavefns: {}", self.output.save_wavefns),
                      format!("Save potential: {}", self.output.save_potential),
+                     width = colwidth);
+            println!("{:5}{:<width$}{:<width$}",
+                     "",
+                     format!("CD precision: {}", self.central_difference),
+                     format!("Output file format: {}", if self.output.binary_files { "Binary"} else { "Plaintext" }),
                      width = colwidth);
             println!("{:5}{:<twidth$}{:<width$}",
                      "",

--- a/src/config.rs
+++ b/src/config.rs
@@ -199,6 +199,25 @@ pub enum CentralDifference {
     SevenPoint,
 }
 
+impl CentralDifference {
+    /// Grabs the **B** ounding **B** ox size for the current precision.
+    pub fn bb(&self) -> usize {
+        match *self {
+            CentralDifference::ThreePoint => 2,
+            CentralDifference::FivePoint => 4,
+            CentralDifference::SevenPoint => 6,
+        }
+    }
+    /// Grabs how much the work area is extended in one direction for the current precision.
+    pub fn ext(&self) -> usize {
+        match *self {
+            CentralDifference::ThreePoint => 1,
+            CentralDifference::FivePoint => 2,
+            CentralDifference::SevenPoint => 3,
+        }
+    }
+}
+
 impl fmt::Display for CentralDifference {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
@@ -561,10 +580,10 @@ fn read_file<P: AsRef<Path>>(file_path: P) -> Result<String, Error> {
 pub fn set_initial_conditions(config: &Config, log: &Logger) -> Result<Array3<f64>, Error> {
     info!(log, "Setting initial conditions for wavefunction");
     let num = &config.grid.size;
-    //NOTE: Don't forget that sizes are non inclusive. We want num.n + 5 to be our last value, so we need num.n + 6 here.
-    let init_size: [usize; 3] = [(num.x + 6) as usize,
-                                 (num.y + 6) as usize,
-                                 (num.z + 6) as usize];
+    let bb = config.central_difference.bb();
+    let init_size: [usize; 3] = [num.x as usize + bb,
+                                 num.y as usize + bb,
+                                 num.z as usize + bb];
     let mut w: Array3<f64> = match config.init_condition {
         InitialCondition::FromFile => {
             input::wavefunction(config.wavenum, init_size, config.output.binary_files, log)?
@@ -576,18 +595,18 @@ pub fn set_initial_conditions(config: &Config, log: &Logger) -> Result<Array3<f6
     };
 
     //Enforce Boundary Conditions
-    // NOTE: Don't forget that ranges are non-inclusive. So 0..3 means 'select 0,1,2'.
+    let ext = config.central_difference.ext();
     // In Z
-    w.slice_mut(s![.., .., 0..3]).par_map_inplace(|el| *el = 0.);
-    w.slice_mut(s![.., .., (init_size[2] - 3) as isize..init_size[2] as isize])
+    w.slice_mut(s![.., .., 0..ext]).par_map_inplace(|el| *el = 0.);
+    w.slice_mut(s![.., .., (init_size[2] - ext) as isize..init_size[2] as isize])
         .par_map_inplace(|el| *el = 0.);
     // In X
-    w.slice_mut(s![0..3, .., ..]).par_map_inplace(|el| *el = 0.);
-    w.slice_mut(s![(init_size[0] - 3) as isize..init_size[0] as isize, .., ..])
+    w.slice_mut(s![0..ext, .., ..]).par_map_inplace(|el| *el = 0.);
+    w.slice_mut(s![(init_size[0] - ext) as isize..init_size[0] as isize, .., ..])
         .par_map_inplace(|el| *el = 0.);
     // In Y
-    w.slice_mut(s![.., 0..3, ..]).par_map_inplace(|el| *el = 0.);
-    w.slice_mut(s![.., (init_size[1] - 3) as isize..init_size[1] as isize, ..])
+    w.slice_mut(s![.., 0..ext, ..]).par_map_inplace(|el| *el = 0.);
+    w.slice_mut(s![.., (init_size[1] - ext) as isize..init_size[1] as isize, ..])
         .par_map_inplace(|el| *el = 0.);
 
     //NOTE: qfdtd has a zeroing out of W here. We are yet to impliment (may not need W).

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,17 +116,18 @@ fn main() {
     };
 
     //Setup logging.
-    let log_file = match OpenOptions::new()
-        .create(true)
-        .write(true)
-        .truncate(true)
-        .open(output::get_project_dir(&config.project_name) + "/simulation.log") {
-        Ok(f) => f,
-        Err(err) => {
-            println!("Could not connect to log file: {}", err);
-            process::exit(1);
-        }
-    };
+    let log_file =
+        match OpenOptions::new()
+                  .create(true)
+                  .write(true)
+                  .truncate(true)
+                  .open(output::get_project_dir(&config.project_name) + "/simulation.log") {
+            Ok(f) => f,
+            Err(err) => {
+                println!("Could not connect to log file: {}", err);
+                process::exit(1);
+            }
+        };
     let syslog = slog_term::PlainDecorator::new(log_file);
     let sys_drain = slog_term::FullFormat::new(syslog).build().fuse();
     let sys_drain = slog_async::Async::new(sys_drain).build().fuse();
@@ -139,7 +140,8 @@ fn main() {
         1 => Level::Info,
         2 | _ => Level::Debug,
     };
-    let log = Logger::root(Fuse::new(Duplicate::new(LevelFilter::new(screen_drain, screen_level), sys_drain)),
+    let log = Logger::root(Fuse::new(Duplicate::new(LevelFilter::new(screen_drain, screen_level),
+                                                    sys_drain)),
                            o!());
 
     info!(log, "Starting Wafer solver"; "version" => crate_version!(), "build-id" => short_sha());

--- a/src/output.rs
+++ b/src/output.rs
@@ -141,15 +141,15 @@ pub fn print_banner(sha: &str) {
 /// *`v` - The potential to output.
 /// * `project` - The project name (for directory to save to).
 /// * `binary` - Bool to identify what type of file to be output (plain text or messagepack).
-pub fn potential(v: &Array3<f64>, project: &str, binary: bool) -> Result<(), Error> {
+pub fn potential(v: &Array3<f64>, bb: usize, project: &str, binary: bool) -> Result<(), Error> {
     let filename = format!("{}/potential.{}",
                            get_project_dir(project),
                            if binary { "mpk" } else { "csv" });
 
     if binary {
-        potential_binary(v, &filename)
+        potential_binary(v, bb, &filename)
     } else {
-        potential_plain(v, &filename)
+        potential_plain(v, bb, &filename)
     }
 }
 
@@ -158,9 +158,9 @@ pub fn potential(v: &Array3<f64>, project: &str, binary: bool) -> Result<(), Err
 /// # Arguments
 /// *`v` - The potential to output
 /// * `filename` - file / directory to save to.
-fn potential_plain(v: &Array3<f64>, filename: &str) -> Result<(), Error> {
+fn potential_plain(v: &Array3<f64>, bb: usize, filename: &str) -> Result<(), Error> {
     let mut buffer = File::create(filename)?;
-    let work = grid::get_work_area(v);
+    let work = grid::get_work_area(v, bb);
     for ((i, j, k), el) in work.indexed_iter() {
         let output = format!("{}, {}, {}, {:e}\n", i, j, k, el);
         buffer.write_all(output.as_bytes())?;
@@ -173,10 +173,10 @@ fn potential_plain(v: &Array3<f64>, filename: &str) -> Result<(), Error> {
 /// # Arguments
 /// *`v` - The potential to output
 /// * `filename` - file / directory to save to.
-fn potential_binary(v: &Array3<f64>, filename: &str) -> Result<(), Error> {
+fn potential_binary(v: &Array3<f64>, bb: usize, filename: &str) -> Result<(), Error> {
     //NOTE: The code below should work, but we must wait for ndarray to have serde 1.0 compatability.
     //For now, we just output to plain instead.
-    potential_plain(v, filename)
+    potential_plain(v, bb, filename)
     //let mut output = Vec::new();
     //v.serialize(&mut rmps::Serializer::new(&mut output))?;
     //let mut buffer = File::create(filename)?;

--- a/wafer.cfg
+++ b/wafer.cfg
@@ -10,6 +10,7 @@
         "dt": 3e-5
     },
     "tolerance": 1e-4,
+    "central_difference": "SevenPoint",
     "max_steps": 50000000,
     "wavenum": 0,
     "wavemax": 1,


### PR DESCRIPTION
This PR implements #2. We add `CentralDifference` type with a configuration option in `wafer.cfg`. It has two methods: ´bb` (bounding box) and `ext` (extent). For `SevenPoint` these methods return 6 and 3 respectively, as this is what has previously been hard coded. There now is an option for three and five point methods also. 

Benchmarking shows we're not too bad when we extend to higher orders (however, a step size optimisation was not performed, so that may alter slightly).
All other items being the same, we arrive at:

    Three: 3 minutes, 13.081 seconds
    Five : 3 minutes, 15.915 seconds
    Seven: 3 minutes, 47.309 seconds

for a boolean test grid, 1 excited state run on Jnana.