### PR TITLE
Scripting input

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: rust
+sudo: required
+# use trusty for newer openblas
+dist: trusty
+rust:
+  - stable
+  - beta
+  - nightly
+matrix:
+  allow_failures:
+    - rust: nightly
+branches:
+  only:
+    - master
+addons:
+  apt:
+    packages:
+      - libopenblas-dev
+      - gfortran

--- a/gen_potential.py
+++ b/gen_potential.py
@@ -13,11 +13,6 @@ Input should be in the form:
         "y": 50,
         "z": 50,
         "dn": 0.01
-    },
-    "idx": {
-        "x": 2,
-        "y": 30,
-        "z": 6
     }
 }
 
@@ -54,19 +49,19 @@ extent_x = (data["grid"]["dn"]*data["grid"]["x"]-data["grid"]["dn"])/2;
 extent_y = (data["grid"]["dn"]*data["grid"]["y"]-data["grid"]["dn"])/2;
 extent_z = (data["grid"]["dn"]*data["grid"]["z"]-data["grid"]["dn"])/2;
 
+# Generate a grid to calculate on
 sx = np.linspace(-extent_x, extent_x, data["grid"]["x"])
 sy = np.linspace(-extent_y, extent_y, data["grid"]["y"])
 sz = np.linspace(-extent_z, extent_z, data["grid"]["z"])
+x, y, z = np.meshgrid(sx, sy, sz, indexing='ij')
 
-# If you need a grid to calculate on:
-#x, y, z = np.meshgrid(sx, sy, sz, indexing='ij')
-# But we just want one value, so:
-x = sx[data["idx"]["x"]]
-y = sy[data["idx"]["y"]]
-z = sz[data["idx"]["z"]]
-
-#Compute potiential
+# Compute potiential
 coeff = -(lam*(lam+1))/2
 V = coeff*(sech(x)*sech(x)) + coeff*(sech(y)*sech(y)) + coeff*(sech(z)*sech(z))
 
-print(V)
+# Output to screen
+for outer in V:
+    for middle in outer:
+        for inner in middle:
+            print(inner)
+

--- a/gen_potential.py
+++ b/gen_potential.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+'''
+Script that generates a custom potential for Wafer.
+Should read stdin an print to stdout. There may be stronger coupling
+in a future version, but for now this allows the user to test the script
+without invoking Wafer each time.
+
+Input should be in the form:
+
+{
+    "grid": {
+        "x": 50,
+        "y": 50,
+        "z": 50,
+        "dn": 0.01
+    },
+    "idx": {
+        "x": 2,
+        "y": 30,
+        "z": 6
+    }
+}
+
+which is a json structure Wafer will send. For testing it's possible to put this
+in a file (e.g. test.json) and invoke the script via
+
+cat test.json | ./gen_potential.py
+
+which will print the potiential value at idx if all goes well.
+
+The script can be renamed/copied to anything else. Just don't forget to call wafer with
+the -s or --script flag.
+'''
+
+from __future__ import print_function
+
+import sys, json;
+import numpy as np
+
+def sech(n):
+    return 1/np.cosh(n)
+
+# Load data from stdin
+data = json.load(sys.stdin)
+
+# This example script calculates the symmetric Poschl-Teller potential, which is
+# analytically solvable in one dimension.
+
+# Value of \lambda, can be set by user.
+lam = 6
+
+# Find out how deep in {x,y,z} we extend from a central point of {0,0,0}
+extent_x = (data["grid"]["dn"]*data["grid"]["x"]-data["grid"]["dn"])/2;
+extent_y = (data["grid"]["dn"]*data["grid"]["y"]-data["grid"]["dn"])/2;
+extent_z = (data["grid"]["dn"]*data["grid"]["z"]-data["grid"]["dn"])/2;
+
+sx = np.linspace(-extent_x, extent_x, data["grid"]["x"])
+sy = np.linspace(-extent_y, extent_y, data["grid"]["y"])
+sz = np.linspace(-extent_z, extent_z, data["grid"]["z"])
+
+# If you need a grid to calculate on:
+#x, y, z = np.meshgrid(sx, sy, sz, indexing='ij')
+# But we just want one value, so:
+x = sx[data["idx"]["x"]]
+y = sy[data["idx"]["y"]]
+z = sz[data["idx"]["z"]]
+
+#Compute potiential
+coeff = -(lam*(lam+1))/2
+V = coeff*(sech(x)*sech(x)) + coeff*(sech(y)*sech(y)) + coeff*(sech(z)*sech(z))
+
+print(V)

--- a/src/config.rs
+++ b/src/config.rs
@@ -379,7 +379,9 @@ impl Config {
         Config::parse(&decoded_config)?;
 
         if let PotentialType::FromScript = decoded_config.potential {
-            decoded_config.script_location = Some(script.to_owned());
+            let mut locale = "./".to_string();
+            locale.push_str(script);
+            decoded_config.script_location = Some(locale);
         } else {
             decoded_config.script_location = None;
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -363,23 +363,27 @@ pub struct Config {
     pub sig: f64,
     /// Symmetry contitions forced upon the wavefuntion.
     init_symmetry: SymmetryConstraint,
+    /// Location of the script if using one. This is not required in the input configuration and will
+    /// be set as a default vaule or derrived from command line arguments.
+    #[serde(skip_deserializing)]
+    pub script_location: Option<String>,
 }
 
 impl Config {
-    /// Reads and parses data from the `wafer.cfg` file.
-    ///
-    /// # Panics
-    ///
-    /// Will dump if we see a file i/o error reading `wafer.cfg`; if the
-    /// contents of this file are not valid *json* (soon to be *hjson*
-    /// to minimise this possibility); and finally there are a number of checks
-    /// on bounds of the user input. For example; grid.dt ≤ grid.dn²/3.
-    pub fn load(file: &str) -> Result<Config, Error> {
+    /// Reads and parses data from the `wafer.cfg` file and command line arguments.
+    pub fn load(file: &str, script: &str) -> Result<Config, Error> {
         //Read in configuration file (hjson format)
         let raw_config = read_file(file)?;
         // Decode configuration file.
-        let decoded_config: Config = serde_json::from_str(&raw_config)?;
+        let mut decoded_config: Config = serde_json::from_str(&raw_config)?;
         Config::parse(&decoded_config)?;
+
+        if let PotentialType::FromScript = decoded_config.potential {
+            decoded_config.script_location = Some(script.to_owned());
+        } else {
+            decoded_config.script_location = None;
+        }
+
         Ok(decoded_config)
     }
 

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -113,7 +113,7 @@ pub fn run(config: &Config, log: &Logger) -> Result<(), Error> {
     if config.wavenum > 0 {
         //We require wavefunctions from disk, even if initial condition is not `FromFile`
         //The wavenum = 0 case is handled later
-        input::load_wavefunctions(config, log, config.output.binary_files, &mut w_store)?;
+        input::load_wavefunctions(config, log, &mut w_store)?;
     }
 
     info!(log, "Starting calculation");

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,7 @@ extern crate rmp_serde as rmps;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
+#[macro_use]
 extern crate serde_json;
 #[macro_use]
 extern crate slog;

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,6 +95,12 @@ fn main() {
                                     .value_name("FILE")
                                     .help("The configuration file to use (default is \"wafer.cfg\")")
                                     .takes_value(true))
+                        .arg(Arg::with_name("script")
+                                    .short("s")
+                                    .long("script")
+                                    .value_name("FILE")
+                                    .help("The potential generation script to use (default is \"gen_potential.py\")")
+                                    .takes_value(true))
                         .arg(Arg::with_name("debug")
                                     .short("d")
                                     .multiple(true)
@@ -103,7 +109,8 @@ fn main() {
 
     //Load configuation parameters.
     let config_file = matches.value_of("config").unwrap_or("wafer.cfg");
-    let config = match Config::load(config_file) {
+    let script_file = matches.value_of("script").unwrap_or("gen_potential.py");
+    let config = match Config::load(config_file, script_file) {
         Ok(c) => c,
         Err(err) => {
             println!("Error processing configuration: {}", err);

--- a/src/potential.rs
+++ b/src/potential.rs
@@ -140,10 +140,7 @@ pub fn load_arrays(config: &Config, log: &Logger) -> Result<Potentials, Error> {
             match config.script_location {
                 Some(ref file) => {
                     match input::script_potential(&file, &config.grid, bb, log) {
-                        Ok(pot) => {
-                            println!("{:?}", pot);
-                            Ok(pot)
-                        },
+                        Ok(pot) => Ok(pot),
                         Err(err) => Err(Error::Input(err)),
                     }
                 }

--- a/src/potential.rs
+++ b/src/potential.rs
@@ -29,6 +29,8 @@ pub enum Error {
     /// In particlular the `from_script` and `from_file` types have limited
     /// functionality here and must be handled separately.
     NotAvailable,
+    /// Something happened with the script handling
+    Script,
     /// From `input`.
     Input(input::Error),
     /// From `output`.
@@ -42,6 +44,7 @@ impl fmt::Display for Error {
                 write!(f,
                        "Not able to calculate potential value at an index for this potential type.")
             }
+            Error::Script => write!(f, "Could not identify location of potential script."),
             Error::Input(ref err) => err.fmt(f),
             Error::Output(ref err) => err.fmt(f),
         }
@@ -52,6 +55,7 @@ impl error::Error for Error {
     fn description(&self) -> &str {
         match *self {
             Error::NotAvailable => "not available",
+            Error::Script => "no script file",
             Error::Input(ref err) => err.description(),
             Error::Output(ref err) => err.description(),
         }
@@ -60,6 +64,7 @@ impl error::Error for Error {
     fn cause(&self) -> Option<&error::Error> {
         match *self {
             Error::NotAvailable => None,
+            Error::Script => None,
             Error::Input(ref err) => Some(err),
             Error::Output(ref err) => Some(err),
         }
@@ -106,16 +111,6 @@ pub fn generate(config: &Config) -> Result<Array3<f64>, Error> {
     Ok(v)
 }
 
-/// Loads a pre-calculated potential from a user defined script.
-pub fn from_script() -> Result<Array3<f64>, Error> {
-    //TODO: This is currently just a placeholder.
-    let ret = 2.3;
-    let mut v = Array3::<f64>::zeros((2, 2, 2));
-
-    Zip::from(&mut v).par_apply(|x| *x = ret);
-    Ok(v)
-}
-
 /// Handles the potential loading from file, or generating depending on configuration
 /// Ancillary arrays are also generated here.
 ///
@@ -141,7 +136,20 @@ pub fn load_arrays(config: &Config, log: &Logger) -> Result<Potentials, Error> {
                 Err(err) => Err(Error::Input(err)),
             }
         }
-        PotentialType::FromScript => from_script(),
+        PotentialType::FromScript => {
+            match config.script_location {
+                Some(ref file) => {
+                    match input::script_potential(&file, &config.grid, bb, log) {
+                        Ok(pot) => {
+                            println!("{:?}", pot);
+                            Ok(pot)
+                        },
+                        Err(err) => Err(Error::Input(err)),
+                    }
+                }
+                None => Err(Error::Script),
+            }
+        }
         _ => {
             info!(log, "Calculating potential array");
             generate(config)
@@ -344,11 +352,11 @@ pub fn potential_sub(config: &Config) -> Result<f64, Error> {
         PotentialType::Harmonic |
         PotentialType::ComplexHarmonic |
         PotentialType::Dodecahedron |
+        PotentialType::FromScript | //TODO: Script should be treated differently.
         PotentialType::FromFile => Ok(0.0),
         PotentialType::ElipticalCoulomb => Ok(1. / config.grid.dn),
         PotentialType::SimpleCornell => Ok(4.0 * config.mass),
-        PotentialType::FullCornell |
-        PotentialType::FromScript => Err(Error::NotAvailable), //TODO: Script may not need to error.
+        PotentialType::FullCornell => Err(Error::NotAvailable),
     }
 }
 

--- a/wafer.cfg
+++ b/wafer.cfg
@@ -20,7 +20,7 @@
         "y": 500,
         "z": 500
     },
-    "potential": "Harmonic",
+    "potential": "FromScript",
     "mass": 15.9994,
     "init_condition": "Gaussian",
     "sig": 1.0,

--- a/wafer.cfg
+++ b/wafer.cfg
@@ -2,9 +2,9 @@
     "project_name": "develop",
     "grid": {
         "size": {
-            "x": 50,
+            "x": 20,
             "y": 50,
-            "z": 50
+            "z": 30
         },
         "dn": 0.01,
         "dt": 3e-5


### PR DESCRIPTION
Implements #20. 

Script expects to read from stdin, and wants a json struct with the following info:

``` json
{
    "grid": {
        "x": 50,
        "y": 50,
        "z": 50,
        "dn": 0.01
    }
}
```

which is designed to be extensible, but for now this is what Wa*f*er will send it. Totally possible to call the script from the command line to test its output too. The script will output the result to stdout, which is captured and used as an input.

Additions to the rust codebase include a non-serialisable item in the config struct which lists the location of the script, as well as a command line option to give a custom location.