### PR TITLE
Error chain handling of errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ chrono = "0.3"
 clap = "~2.24.2"
 clippy = {git = "https://github.com/Manishearth/rust-clippy", optional = true}
 csv = "1.0.0-beta.3"
+error-chain = "0.10"
 indicatif = "0.5"
 lazy_static = "0.2"
 ndarray = { version = "0.9", features = ["blas"] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -260,8 +260,6 @@ pub enum Error {
     LargeDt,
     /// If `wavenum` is larger than `wavemax`.
     LargeWavenum,
-    /// From `input`.
-    Input(input::Error),
     /// From `output`.
     Output(output::Error),
 }
@@ -278,7 +276,6 @@ impl fmt::Display for Error {
             Error::LargeWavenum => {
                 write!(f, "Config Error: wavenum can not be larger than wavemax")
             }
-            Error::Input(ref err) => err.fmt(f),
             Error::Output(ref err) => err.fmt(f),
         }
     }
@@ -291,7 +288,6 @@ impl error::Error for Error {
             Error::DecodeYaml(ref err) => err.description(),
             Error::LargeDt => "grid.dt >= grid.dn²/3",
             Error::LargeWavenum => "wavenum > wavemax",
-            Error::Input(ref err) => err.description(),
             Error::Output(ref err) => err.description(),
         }
     }
@@ -301,7 +297,6 @@ impl error::Error for Error {
             Error::Io(ref err) => Some(err),
             Error::DecodeYaml(ref err) => Some(err),
             Error::LargeDt | Error::LargeWavenum => None,
-            Error::Input(ref err) => Some(err),
             Error::Output(ref err) => Some(err),
         }
     }
@@ -316,12 +311,6 @@ impl From<io::Error> for Error {
 impl From<serde_yaml::Error> for Error {
     fn from(err: serde_yaml::Error) -> Error {
         Error::DecodeYaml(err)
-    }
-}
-
-impl From<input::Error> for Error {
-    fn from(err: input::Error) -> Error {
-        Error::Input(err)
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,13 +3,12 @@ use ndarray_parallel::prelude::*;
 use rand::distributions::{Normal, IndependentSample};
 use rand;
 use slog::Logger;
-use std::error;
 use std::fmt;
-use std::io;
 use std::fs::File;
 use serde_yaml;
 use input;
 use output;
+use errors::*;
 
 /// Grid size information.
 #[derive(Serialize, Deserialize, Debug)]
@@ -249,77 +248,6 @@ impl fmt::Display for RunType {
     }
 }
 
-/// Error type for handling the configuration stucts.
-#[derive(Debug)]
-pub enum Error {
-    /// From disk issues.
-    Io(io::Error),
-    /// From `serde_yaml`.
-    DecodeYaml(serde_yaml::Error),
-    /// If temporal step `dt` is larger than `dn`^2/3.
-    LargeDt,
-    /// If `wavenum` is larger than `wavemax`.
-    LargeWavenum,
-    /// From `output`.
-    Output(output::Error),
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            Error::Io(ref err) => err.fmt(f),
-            Error::DecodeYaml(ref err) => err.fmt(f),
-            Error::LargeDt => {
-                write!(f,
-                       "Config Error: Temporal step (grid.dt) must be less than or equal to grid.dn²/3")
-            }
-            Error::LargeWavenum => {
-                write!(f, "Config Error: wavenum can not be larger than wavemax")
-            }
-            Error::Output(ref err) => err.fmt(f),
-        }
-    }
-}
-
-impl error::Error for Error {
-    fn description(&self) -> &str {
-        match *self {
-            Error::Io(ref err) => err.description(),
-            Error::DecodeYaml(ref err) => err.description(),
-            Error::LargeDt => "grid.dt >= grid.dn²/3",
-            Error::LargeWavenum => "wavenum > wavemax",
-            Error::Output(ref err) => err.description(),
-        }
-    }
-
-    fn cause(&self) -> Option<&error::Error> {
-        match *self {
-            Error::Io(ref err) => Some(err),
-            Error::DecodeYaml(ref err) => Some(err),
-            Error::LargeDt | Error::LargeWavenum => None,
-            Error::Output(ref err) => Some(err),
-        }
-    }
-}
-
-impl From<io::Error> for Error {
-    fn from(err: io::Error) -> Error {
-        Error::Io(err)
-    }
-}
-
-impl From<serde_yaml::Error> for Error {
-    fn from(err: serde_yaml::Error) -> Error {
-        Error::DecodeYaml(err)
-    }
-}
-
-impl From<output::Error> for Error {
-    fn from(err: output::Error) -> Error {
-        Error::Output(err)
-    }
-}
-
 /// The main struct which all input data from `wafer.cfg` is pushed into.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Config {
@@ -370,10 +298,10 @@ pub struct Config {
 
 impl Config {
     /// Reads and parses data from the `wafer.cfg` file and command line arguments.
-    pub fn load(file: &str, script: &str) -> Result<Config, Error> {
-        let reader = File::open(file)?;
+    pub fn load(file: &str, script: &str) -> Result<Config> {
+        let reader = File::open(file).chain_err(|| ErrorKind::ConfigLoad(file.to_string()))?;
         // Decode configuration file.
-        let mut decoded_config: Config = serde_yaml::from_reader(reader)?;
+        let mut decoded_config: Config = serde_yaml::from_reader(reader).chain_err(|| ErrorKind::Deserialize)?;
         Config::parse(&decoded_config)?;
 
         if let PotentialType::FromScript = decoded_config.potential {
@@ -393,12 +321,12 @@ impl Config {
 
     /// Additional checks to the configuration file that cannot be done implicitly
     /// by the type checker.
-    fn parse(&self) -> Result<(), Error> {
+    fn parse(&self) -> Result<()> {
         if self.grid.dt > self.grid.dn.powi(2) / 3. {
-            return Err(Error::LargeDt);
+            return Err(ErrorKind::LargeDt.into());
         }
         if self.wavenum > self.wavemax {
-            return Err(Error::LargeWavenum);
+            return Err(ErrorKind::LargeWavenum.into());
         }
         Ok(())
     }
@@ -572,7 +500,7 @@ impl Config {
 ///
 /// * `config` - a reference to the configuration struct.
 /// * `log` - a reference to the logger.
-pub fn set_initial_conditions(config: &Config, log: &Logger) -> Result<Array3<f64>, Error> {
+pub fn set_initial_conditions(config: &Config, log: &Logger) -> Result<Array3<f64>> {
     info!(log, "Setting initial conditions for wavefunction");
     let num = &config.grid.size;
     let bb = config.central_difference.bb();

--- a/src/config.rs
+++ b/src/config.rs
@@ -302,7 +302,7 @@ impl Config {
         let reader = File::open(file).chain_err(|| ErrorKind::ConfigLoad(file.to_string()))?;
         // Decode configuration file.
         let mut decoded_config: Config = serde_yaml::from_reader(reader).chain_err(|| ErrorKind::Deserialize)?;
-        Config::parse(&decoded_config)?;
+        Config::parse(&decoded_config).chain_err(|| ErrorKind::ConfigParse)?;
 
         if let PotentialType::FromScript = decoded_config.potential {
             let mut locale = "./".to_string();
@@ -314,7 +314,7 @@ impl Config {
 
         // Setup ouput directory and copy configuration.
         output::check_output_dir(&decoded_config.project_name)?;
-        output::copy_config(&decoded_config.project_name, file)?;
+        output::copy_config(&decoded_config.project_name, &file).chain_err(|| ErrorKind::CopyConfig(file.to_string()))?;
 
         Ok(decoded_config)
     }
@@ -513,7 +513,7 @@ pub fn set_initial_conditions(config: &Config, log: &Logger) -> Result<Array3<f6
                                 init_size,
                                 bb,
                                 config.output.binary_files,
-                                log)?
+                                log).chain_err(|| ErrorKind::LoadWavefunction(config.wavenum))?
         }
         InitialCondition::Gaussian => generate_gaussian(config, init_size),
         InitialCondition::Coulomb => generate_coulomb(config, init_size),

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,55 @@
+error_chain!{
+    errors {
+        ConfigLoad(path: String) {
+                description("Config file not found")
+                display("Unable to read file `{}`", path)
+        }
+
+        ConfigParse {
+            description("Error parsing config")
+            display("an error occurred trying to parse the configuratation file")
+        }
+
+        CreateLog(path: String) {
+                description("Cannot write log file")
+                display("Unable to write log file `{}`", path)
+        }
+
+        FileNotFound(path: String) {
+                description("File not found")
+                display("Unable to find file `{}`", path)
+        }
+        CreateInputDir {
+                description("Cannot create input dir")
+                display("Unable to create an input directory")
+        }
+        CreateFile(file: String) {
+                description("Cannot create file")
+                display("Unable to create {}", file)
+        }
+        ParseFloat {
+                description("Cannot parse float")
+                display("Unable to parse string to f64")
+        }
+        ParsePlainRecord(file: String) {
+                description("Cannot parse csv data")
+                display("Unable to parse a string of data into a valid record from file {}", file)
+        }
+        ArrayShape(len: usize, dims: [usize;3]) {
+                description("Cannot reshape array")
+                display("Unable to reshape vector with length {} into an array with dimensions {:?}", len, dims)
+        }
+        StdIn {
+                description("Cannot write to stdin")
+                display("Unable to write to stdin in of the python script process")
+        }
+        StdOut {
+                description("Cannot recieve stdout")
+                display("Unable to recieve data from stdout of the python script process")
+        }
+        SpawnPython {
+                description("Cannot spawn script")
+                display("Unable to spawn a python script process")
+        }
+    }
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -23,6 +23,10 @@ error_chain!{
                 description("Cannot create input dir")
                 display("Unable to create an input directory")
         }
+        CreateOutputDir(path: String) {
+                description("Cannot create output dir")
+                display("Unable to create the output directory '{}'", path)
+        }
         CreateFile(file: String) {
                 description("Cannot create file")
                 display("Unable to create {}", file)
@@ -50,6 +54,22 @@ error_chain!{
         SpawnPython {
                 description("Cannot spawn script")
                 display("Unable to spawn a python script process")
+        }
+        SaveObservables {
+                description("Cannot save observables")
+                display("Unable to save observables data to disk")
+        }
+        Serialize {
+                description("Cannot serialize data")
+                display("Unable to serialize data from struct")
+        }
+        Deserialize {
+                description("Cannot deserialize data")
+                display("Unable to deserialize data to required struct")
+        }
+        Flush {
+                description("Cannot flush")
+                display("Unable to flush io buffer")
         }
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -10,6 +10,15 @@ error_chain!{
             display("an error occurred trying to parse the configuratation file")
         }
 
+        LargeDt {
+            description("grid.dt >= grid.dn²/3")
+            display("Temporal step (grid.dt) must be less than or equal to grid.dn²/3")
+        }
+        LargeWavenum {
+            description("wavenum > wavemax")
+            display("Wavenum can not be larger than wavemax")
+        }
+
         CreateLog(path: String) {
                 description("Cannot write log file")
                 display("Unable to write log file `{}`", path)
@@ -70,6 +79,18 @@ error_chain!{
         Flush {
                 description("Cannot flush")
                 display("Unable to flush io buffer")
+        }
+        MaxStep {
+                description("Maximum step reached")
+                display("Maximum step limit reached, halting operation")
+        }
+        PotentialNotAvailable {
+                description("Not available for PotentialType")
+                display("Invalid call for current potential type")
+        }
+        ScriptNotFound {
+                description("Cannot find script")
+                display("Unable to locate potential script")
         }
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -10,6 +10,10 @@ error_chain!{
             display("an error occurred trying to parse the configuratation file")
         }
 
+        SetInitialConditions {
+            description("Error setting initial conditions")
+            display("an error occurred trying to set the initialisation conditions on the starting wavefunction")
+        }
         LargeDt {
             description("grid.dt >= grid.dn²/3")
             display("Temporal step (grid.dt) must be less than or equal to grid.dn²/3")
@@ -91,6 +95,26 @@ error_chain!{
         ScriptNotFound {
                 description("Cannot find script")
                 display("Unable to locate potential script")
+        }
+        CopyConfig(file: String) {
+                description("Cannot copy configuration")
+                display("Unable to copy configuration file '{}' to output directory", file)
+        }
+        LoadWavefunction(wnum: u8) {
+                description("Cannot load wavefunction")
+                display("Unable to load wavefunction {} from disk", wnum)
+        }
+        LoadPotential {
+                description("Cannot load potential")
+                display("Unable to load potential from disk")
+        }
+        SaveWavefunction(wnum: u8) {
+                description("Cannot save wavefunction")
+                display("Unable to save wavefunction {} to disk", wnum)
+        }
+        SavePotential {
+                description("Cannot save potential")
+                display("Unable to save potential to disk")
         }
     }
 }

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -182,7 +182,7 @@ fn solve(config: &Config,
         w_store.push(phi); //Save state
         Ok(())
     } else {
-        Err(Error::MaxStep)
+        Err(ErrorKind::MaxStep.into())
     }
 }
 

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -91,7 +91,7 @@ fn solve(config: &Config,
         }
     } else {
         //This sorts out loading from disk if we are on wavefunction 0.
-        config::set_initial_conditions(config, log)?
+        config::set_initial_conditions(config, log).chain_err(|| ErrorKind::SetInitialConditions)?
     };
 
     output::print_observable_header(wnum);

--- a/src/input.rs
+++ b/src/input.rs
@@ -67,7 +67,7 @@ pub fn potential(target_size: [usize; 3],
     } else {
         None
     };
-    println!("{:?}, {:?}", plain_file, binary_file);
+
     if plain_file.is_some() && binary_file.is_some() {
         warn!(log,
               "Multiple potential files found in input directory. Chosing 'potential.{}' based on configuration settings.",
@@ -180,9 +180,7 @@ pub fn load_wavefunctions(config: &Config,
         let wfn = wavefunction(wnum, init_size, bb, config.output.binary_files, log);
         match wfn {
             Ok(w) => w_store.push(w),
-            Err(err) => return Err(err),
-            //TODO: Probably need to make these errors a litte more expressive in thier format sections. For example:
-            //    panic!("Cannot load any wavefunction_{}* file from input folder: {}", wnum, err)
+            Err(_) => return Err(ErrorKind::LoadWavefunction(wnum).into()),
         }
         info!(log, "Loaded (previous) wavefunction {} from disk", wnum);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,11 +19,16 @@
 #![cfg_attr(feature="clippy", warn(missing_docs_in_private_items))]
 #![cfg_attr(feature="clippy", warn(single_match_else))]
 
+// `error_chain!` can recurse deeply
+#![recursion_limit = "1024"]
+
 extern crate ansi_term;
 extern crate chrono;
 #[macro_use]
 extern crate clap;
 extern crate csv;
+#[macro_use]
+extern crate error_chain;
 extern crate indicatif;
 #[macro_use]
 extern crate lazy_static;
@@ -55,6 +60,7 @@ use std::process;
 use std::thread;
 use std::time::{Duration, Instant};
 use config::Config;
+use errors::*;
 
 include!(concat!(env!("OUT_DIR"), "/version.rs"));
 
@@ -72,6 +78,8 @@ mod output;
 /// Handles the potential generation, binding energy offsets, callouts to files or scripts
 /// if needed etc.
 mod potential;
+/// Handles the error chain of the program.
+mod errors;
 
 /// Exits (with error, but no display) after a short pause. Because we're using async logs, sometimes we dump before
 /// the log system outputs information. We spool for a little first in these instances so we get the
@@ -121,15 +129,20 @@ fn main() {
     };
 
     //Setup logging.
+    let log_location = output::get_project_dir(&config.project_name) + "/simulation.log";
     let log_file =
         match OpenOptions::new()
                   .create(true)
                   .write(true)
                   .truncate(true)
-                  .open(output::get_project_dir(&config.project_name) + "/simulation.log") {
+                  .open(&log_location)
+                  .chain_err(|| ErrorKind::CreateLog(log_location.to_string())) {
             Ok(f) => f,
-            Err(err) => {
-                println!("Could not connect to log file: {}", err);
+            Err(ref err) => {
+                println!("Error: {}", err);
+                for e in err.iter().skip(1) {
+                    println!("caused by: {}", e);
+                }
                 process::exit(1);
             }
         };
@@ -152,8 +165,11 @@ fn main() {
     info!(log, "Starting Wafer solver"; "version" => crate_version!(), "build-id" => short_sha());
 
     info!(log, "Checking/creating directories");
-    if let Err(err) = input::check_input_dir() {
-        crit!(log, "Could not communicate with input directory: {}", err);
+    if let Err(ref err) = input::check_input_dir() {
+        crit!(log, "{}", err);
+        for e in err.iter().skip(1) {
+            crit!(log, "caused by: {}", e);
+        }
         exit_with_pause();
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -122,8 +122,11 @@ fn main() {
     let script_file = matches.value_of("script").unwrap_or("gen_potential.py");
     let config = match Config::load(config_file, script_file) {
         Ok(c) => c,
-        Err(err) => {
-            println!("Error processing configuration: {}", err);
+        Err(ref err) => {
+            println!("Error loading configuration: {}", err);
+            for e in err.iter().skip(1) {
+                println!("caused by: {}", e);
+            }
             process::exit(1);
         }
     };
@@ -139,7 +142,7 @@ fn main() {
                   .chain_err(|| ErrorKind::CreateLog(log_location.to_string())) {
             Ok(f) => f,
             Err(ref err) => {
-                println!("Error: {}", err);
+                println!("Error initialising log file: {}", err);
                 for e in err.iter().skip(1) {
                     println!("caused by: {}", e);
                 }
@@ -189,8 +192,11 @@ fn main() {
     info!(log, "Loading Configuation from disk");
     config.print(term_width);
 
-    if let Err(err) = grid::run(&config, &log) {
+    if let Err(ref err) = grid::run(&config, &log) {
         crit!(log, "{}", err);
+        for e in err.iter().skip(1) {
+            crit!(log, "caused by: {}", e);
+        }
         exit_with_pause();
     };
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -7,7 +7,6 @@ use serde::Serialize;
 use serde_json;
 use rmps;
 use std::fs::{copy, create_dir_all, File};
-use std::io;
 use std::io::prelude::*;
 use term_size;
 use ansi_term::Colour::Blue;
@@ -360,7 +359,7 @@ fn observables_binary(observables: &ObservablesOutput, project: &str) -> Result<
                            observables.state);
     let mut output = Vec::new();
     observables.serialize(&mut rmps::Serializer::new(&mut output)).chain_err(|| ErrorKind::Serialize)?;
-    let mut buffer = File::create(filename).chain_err(|| ErrorKind::CreateFile(filename))?;
+    let mut buffer = File::create(&filename).chain_err(|| ErrorKind::CreateFile(filename))?;
     buffer.write_all(&output).chain_err(|| ErrorKind::SaveObservables)?;
     Ok(())
 }
@@ -370,7 +369,7 @@ fn observables_plain(observables: &ObservablesOutput, project: &str) -> Result<(
     let filename = format!("{}/observables_{}.json",
                            get_project_dir(project),
                            observables.state);
-    let buffer = File::create(filename).chain_err(|| ErrorKind::CreateFile(filename))?;
+    let buffer = File::create(&filename).chain_err(|| ErrorKind::CreateFile(filename))?;
     serde_json::to_writer_pretty(buffer, observables).chain_err(|| ErrorKind::SaveObservables)?;
     Ok(())
 }
@@ -378,7 +377,7 @@ fn observables_plain(observables: &ObservablesOutput, project: &str) -> Result<(
 /// Generates a unique folder inside an `output` directory for the current simulation.
 pub fn check_output_dir(project: &str) -> Result<()> {
     let proj_dir = get_project_dir(project);
-    create_dir_all(proj_dir).chain_err(|| ErrorKind::CreateOutputDir(proj_dir))?;
+    create_dir_all(&proj_dir).chain_err(|| ErrorKind::CreateOutputDir(proj_dir))?;
     Ok(())
 }
 
@@ -400,7 +399,7 @@ pub fn get_project_dir(project: &str) -> String {
 /// Copies the current configuration file to the project folder
 pub fn copy_config(project: &str, file: &str) -> Result<()> {
     let copy_file = get_project_dir(project) + "/" + file;
-    copy(file, copy_file).chain_err(|| ErrorKind::CreateFile(copy_file))?;
+    copy(file, &copy_file).chain_err(|| ErrorKind::CreateFile(copy_file))?;
     Ok(())
 }
 


### PR DESCRIPTION
The solution to #23 was fine in the sense that it returned the error type up the chain. This is fine for libraries, but for this app, it wasn't that expressive. This PR implements an [error chain](https://github.com/brson/error-chain) which is much more functional in that sense. We get the underlying format of the error types but can also follow the propagation of errors. 

At the moment a number of these pathways have been checked, but not all. So there may be some language changes and additions needed; but this groundwork is orders of magnitude better for user experience than the last solution.